### PR TITLE
ci: add Cloudflare Pages deploy and CI refinements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,16 @@
 name: ci
 
-on: push
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
 
 jobs:
   ci:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node: [22]
+    runs-on: ubuntu-latest
+    env:
+      NUXT_TELEMETRY_DISABLED: '1'
 
     steps:
       - name: Checkout
@@ -18,10 +19,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Install node
+      - name: Install Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -32,3 +33,43 @@ jobs:
 
       - name: Typecheck
         run: pnpm run typecheck
+
+      - name: Build
+        run: pnpm run build
+
+  deploy:
+    name: Deploy to Cloudflare Pages
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NUXT_TELEMETRY_DISABLED: '1'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CF_PAGES_PROJECT_NAME }}
+          directory: .output/public


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve consistency, add a build step, and introduce automated deployment to Cloudflare Pages when changes are pushed to the `main` branch.

**CI workflow improvements:**

* Updated the workflow triggers to run on all branch pushes and pull requests, ensuring CI runs for every code change.
* Simplified the matrix strategy by removing OS and Node.js version matrices, and standardized the environment to always use `ubuntu-latest` and Node.js 22. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL3-R13) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-R25)
* Added the `NUXT_TELEMETRY_DISABLED` environment variable to disable Nuxt telemetry during CI runs.

**Build and deployment automation:**

* Added a build step to the CI workflow to ensure the project is built as part of the pipeline.
* Introduced a new `deploy` job that automatically deploys the built project to Cloudflare Pages when changes are pushed to the `main` branch. This job uses secrets for authentication and only runs after a successful CI build.